### PR TITLE
技術リードとして取り組んだ内容の下書きをPublicationに紐付け

### DIFF
--- a/articles/tech-lead-contents.md
+++ b/articles/tech-lead-contents.md
@@ -3,6 +3,7 @@ title: "チーム開発をうまくやるために技術リードとして取り
 emoji: "🕌"
 type: "idea" # tech: 技術記事 / idea: アイデア
 topics: ["テックリード", "team", "ios", "android"]
+publication_name: "sun_asterisk"
 published: false
 ---
 


### PR DESCRIPTION
### **PR Type**
enhancement, documentation


___

### **Description**
- Added a new metadata field `publication_name` with the value "sun_asterisk" to the article `tech-lead-contents.md`.
- This change links the draft content to a specific publication.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tech-lead-contents.md</strong><dd><code>Add publication name to tech lead article metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

articles/tech-lead-contents.md

- Added `publication_name` field with value "sun_asterisk".



</details>


  </td>
  <td><a href="https://github.com/shotaIDE/zenn/pull/294/files#diff-69aa79ea4e085955f961b7a67cd46338b099065839fe9a71085c3827e64e845b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information