### PR TITLE
FlutterによるiOSアプリでTestFlightにアップロードしたアプリのみ「Appleでサインイン」が失敗するの記事を公開

### DIFF
--- a/articles/sign-in-with-apple-on-ios-by-flutter.md
+++ b/articles/sign-in-with-apple-on-ios-by-flutter.md
@@ -3,7 +3,7 @@ title: "FlutterによるiOSアプリでTestFlightにアップロードしたア�
 emoji: "🍎"
 type: "tech" # tech: 技術記事 / idea: アイデア
 topics: ["flutter", "ios", "xcode", "apple"]
-published: false
+published: true
 ---
 
 <!-- cSpell:ignore textlint, xcarchive -->
@@ -26,7 +26,7 @@ Flutter プロジェクトで「Apple でサインイン」を実装している
 - Flutter プロジェクトにおける iOS アプリ
 - Apple でサインイン機能を実装済み
 
-また、Xcode プロジェクトファイルの設定で、**Automatic Signing を有効に**しています。
+また、**Xcode プロジェクトファイルの設定で、Automatic Signing を有効**にしています。
 
 ![Automatic Signingが有効](/images/sign-in-with-apple-on-ios-by-flutter/automatic-signing.png)
 
@@ -62,7 +62,7 @@ xcodebuild -exportArchive \
 :::
 
 `-exportOptionsPlist` オプションのファイルには、以下のような内容を指定していました。
-**Manual Signing の設定が含まれた**ものになっています。
+Manual Signing の設定が含まれたものになっています。
 
 ```xml:./ios/ExportOptions.plist
 <?xml version="1.0" encoding="UTF-8"?>
@@ -91,14 +91,14 @@ xcodebuild -exportArchive \
 
 ## 結論
 
-Xcode プロジェクトの構成を Manual Signing に変更し、ビルドコマンド時に署名周りの設定を付け替える必要がないようにしました。
+Xcode プロジェクトの構成を Manual Signing に変更し、**ビルドコマンド時に署名周りの設定を付け替える必要がないようにしました**。
 この設定によりビルドしたアプリを Test Flight にアップロードすると、「Apple でサインイン」機能が正常に動作しました。
 
 ## 詳細
 
 具体的には以下の通りの手順で設定しています。
 
-**Xcode プロジェクトファイルの構成そのものを Manual Signing に変更**しました。
+Xcode プロジェクトファイルの構成そのものを Manual Signing に変更しました。
 Test Flight にアップロードする用の構成(`Release-prod`)のみ変更を適用しています。
 
 ![Manual Signingに変更](/images/sign-in-with-apple-on-ios-by-flutter/manual-signing.png)

--- a/articles/sign-in-with-apple-on-ios-by-flutter.md
+++ b/articles/sign-in-with-apple-on-ios-by-flutter.md
@@ -39,24 +39,17 @@ flutter build ios --no-codesign
 
 # iOSネイティブをアーカイブ
 xcodebuild archive \
-  CODE_SIGNING_ALLOWED=NO \
   -workspace ./ios/Runner.xcworkspace \
-  -scheme Runner \
-  -configuration Release \
-  -archivePath ./build/ios/Runner.xcarchive \
-  -authenticationKeyIssuerID "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
-  -authenticationKeyID "XXXXXXXXXX" \
-  -authenticationKeyPath ./ios/fastlane/app-store-connect-api-key.p8
+  -scheme 'prod' \
+  -configuration 'Release-prod' \
+  -archivePath ./build/ios/Runner.xcarchive
 
 # iOSネイティブをipaファイルにエクスポート
 xcodebuild -exportArchive \
   -archivePath ./build/ios/Runner.xcarchive \
   -exportPath ./build/ios/ipa \
   -exportOptionsPlist "${EXPORT_OPTIONS_PLIST_RELATIVE_PATH}" \
-  -allowProvisioningUpdates \
-  -authenticationKeyIssuerID "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
-  -authenticationKeyID "XXXXXXXXXX" \
-  -authenticationKeyPath ./ios/fastlane/app-store-connect-api-key.p8
+  -allowProvisioningUpdates
 ```
 
 :::message

--- a/articles/sign-in-with-apple-on-ios-by-flutter.md
+++ b/articles/sign-in-with-apple-on-ios-by-flutter.md
@@ -52,8 +52,13 @@ xcodebuild -exportArchive \
   -allowProvisioningUpdates
 ```
 
-:::message
+:::message  
 このような段階を踏んだビルド方法を取っていたのは、ローカルマシンの開発時には Automatic Signing を有効にしておきたかったためです。
+:::
+
+:::message
+改めて考えると、Xcode プロジェクトファイルの設定と実際のビルド時の設定を付け替えるのは、そもそもトリッキーですね...😇
+後述していますが、これが原因だったっぽいです。
 :::
 
 `-exportOptionsPlist` オプションのファイルには、以下のような内容を指定していました。


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- 記事を公開状態に変更

- Xcodeビルドコマンドを簡潔化

- 署名キー設定を削除し自動化

- 解説メッセージ追記・強調


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sign-in-with-apple-on-ios-by-flutter.md</strong><dd><code>記事公開＆ビルド署名手順更新</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

articles/sign-in-with-apple-on-ios-by-flutter.md

<li><code>published</code>を<code>true</code>に変更  <br> <li> アーカイブコマンドを<code>prod</code>/<code>Release-prod</code>に更新  <br> <li> 認証キーオプションを削除し署名設定を簡略化  <br> <li> トリッキーさ解説メッセージ追記および強調


</details>


  </td>
  <td><a href="https://github.com/shotaIDE/zenn/pull/346/files#diff-ef818c75fe77ec0301904594aec0c862467e10069848dbba028ace2b507dd7f9">+15/-17</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>