### PR TITLE
Composeで没入感のあるエッジツーエッジのUIを実現する記事の下書きを更新

### DIFF
--- a/articles/edge-to-edge-on-compose.md
+++ b/articles/edge-to-edge-on-compose.md
@@ -18,7 +18,7 @@ https://developers-jp.googleblog.com/2019/10/gesture-navigation-handling-visual-
 一方で、 `contentPadding` によるパディングは、`LazyColumn` のスクロール領域に対して適用されます。
 そのため、`contentPadding` によるパディングを設定することが適切です。
 
-`WindowInsets.safeContent` を利用することで、切り欠きを避けて描画できる。
+`WindowInsets.safeDrawing` を利用することで、切り欠きを避けて描画できる。
 
 | 項目          | Android 15                                       | Android 14                                           |
 | ------------- | ------------------------------------------------ | ---------------------------------------------------- |


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
Composeエッジツーエッジ実装メモを追記
LazyColumnのpadding差分を説明
safeDrawing利用方針を明文化
参考リンクと残課題を追加


___

### Diagram Walkthrough


```mermaid
flowchart LR
  notes["記事: edge-to-edge-on-compose.md 追記"]
  notes -- "LazyColumnのmodifier vs contentPadding" --> padding["paddingの適用範囲を解説"]
  notes -- "WindowInsets.safeDrawing" --> insets["切り欠き回避の方針"]
  notes -- "実装方針" --> policy["スクロール方向ごとの扱い"]
  notes -- "TODOと参考リンク" --> refs["Android公式/Qiitaリンク追加"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>edge-to-edge-on-compose.md</strong><dd><code>エッジツーエッジ実装指針と参考情報を追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

articles/edge-to-edge-on-compose.md

<ul><li>残課題（Android 15未満対応）を追加<br> <li> LazyColumnのmodifierとcontentPaddingの違いを解説<br> <li> WindowInsets.safeDrawingと実装方針を記述<br> <li> 公式/参考リンクを追記</ul>


</details>


  </td>
  <td><a href="https://github.com/shotaIDE/zenn/pull/370/files#diff-ad23c016c5aea16cea8f4dd99bb8e4ad77458768e7265f00ba20097c9db9ffeb">+19/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

