### PR TITLE
Composeで没入感のあるエッジツーエッジのUIを実現する記事を公開

### DIFF
--- a/articles/edge-to-edge-on-compose.md
+++ b/articles/edge-to-edge-on-compose.md
@@ -4,7 +4,7 @@ emoji: "🌟"
 type: "idea" # tech: 技術記事 / idea: アイデア
 topics: ["android", "jetpackcompose"]
 publication_name: "sun_asterisk"
-published: false
+published: true
 ---
 
 <!-- cspell:ignore jetpack, jetpackcompose -->
@@ -152,7 +152,7 @@ Before のコードのように `LazyColumn` の `modifier` で余白を設定�
 +                    LocalLayoutDirection.current
 +                ),
 +                top = 16.dp + innerPadding.calculateTopPadding(),
-+                end = 16.dp + innerPadding.calculateStartPadding(
++                end = 16.dp + innerPadding.calculateEndPadding(
 +                    LocalLayoutDirection.current
 +                ),
 +                bottom = 16.dp + innerPadding.calculateBottomPadding(),


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
記事を公開状態に変更
Padding計算の方向を修正
レイアウト方向対応を改善


___

### Diagram Walkthrough


```mermaid
flowchart LR
  article["記事: edge-to-edge-on-compose.md"]
  publish["公開フラグをtrueに更新"]
  padding["Padding計算: Start→Endに修正"]
  ltrRtl["LTR/RTL対応の明確化"]

  article -- "metadata更新" --> publish
  article -- "コードスニペット修正" --> padding
  padding -- "方向依存の適正化" --> ltrRtl
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>edge-to-edge-on-compose.md</strong><dd><code>記事公開化とPadding方向ロジック修正</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

articles/edge-to-edge-on-compose.md

<ul><li>フロントマターのpublishedをtrueへ<br> <li> コード例のEnd Padding計算へ修正<br> <li> レイアウト方向に合わせたPadding適用</ul>


</details>


  </td>
  <td><a href="https://github.com/shotaIDE/zenn/pull/377/files#diff-ad23c016c5aea16cea8f4dd99bb8e4ad77458768e7265f00ba20097c9db9ffeb">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

